### PR TITLE
Add usable `gym.Wrapper` for `Breakout`: `BreakoutN`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,11 @@ verify_ssl = true
 
 [dev-packages]
 tox = "*"
+ipython = "*"
+jupyter = "*"
+keras = "*"
+tensorflow-gpu = "*"
+keras-rl = "*"
 
 [packages]
 gym = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "077a214823611b0dacd3034f9857d1cef24a641529a647f78e43897eb7e4caf5"
+            "sha256": "8d4730e0ab0080bc51342e057edae8c357e8281991fbe07c51fb5ad629323ced"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -132,12 +132,151 @@
         }
     },
     "develop": {
+        "absl-py": {
+            "hashes": [
+                "sha256:b943d1c567743ed0455878fcd60bc28ac9fae38d129d1ccfad58079da00b8951"
+            ],
+            "version": "==0.7.1"
+        },
+        "astor": {
+            "hashes": [
+                "sha256:0e41295809baf43ae8303350e031aff81ae52189b6f881f36d623fa8b2f1960e",
+                "sha256:37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862"
+            ],
+            "version": "==0.8.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "backcall": {
+            "hashes": [
+                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
+                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+            ],
+            "version": "==0.1.0"
+        },
+        "bleach": {
+            "hashes": [
+                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
+                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
+            ],
+            "version": "==3.1.0"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
+        },
+        "defusedxml": {
+            "hashes": [
+                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
+                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
+            ],
+            "version": "==0.6.0"
+        },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
         "filelock": {
             "hashes": [
                 "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
                 "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
             ],
             "version": "==3.0.12"
+        },
+        "gast": {
+            "hashes": [
+                "sha256:fe939df4583692f0512161ec1c880e0a10e71e6a232da045ab8edd3756fbadf0"
+            ],
+            "version": "==0.2.2"
+        },
+        "google-pasta": {
+            "hashes": [
+                "sha256:40b4f55ba7b44823eac96d055000572c84ce48cacb3e91c100869844064b2d07",
+                "sha256:79d1ce28b381d68e98ef7707d19909adb58912f8dae8734402454424fc76b8fe",
+                "sha256:7ca8afc4cfeebf4a079cdf586333d5447cecd19a997475136138fc83c3351bc4"
+            ],
+            "version": "==0.1.7"
+        },
+        "grpcio": {
+            "hashes": [
+                "sha256:0232add03144dd3cf9b660e2718244cb8e175370dca4d3855cb4e489a7811b53",
+                "sha256:0f20e6dcb1b8662cdca033bb97c0a8116a5343e3ebc7f71c5fe7f89039978350",
+                "sha256:10b07a623d33d4966f45c85d410bc6a79c5ac6341f06c3beda6c22be12cbfe07",
+                "sha256:10c0476d5a52d21f402fc073745dc43b87cc8e080a1f49bbff4e1059019310fb",
+                "sha256:289dae0b35c59d191c524e976dd0a6f8c995d2062e72621eb866ad0f4472a635",
+                "sha256:2be726f16142d358a0df1e81d583d6820ee561a7856a79cca2fbe49989308be7",
+                "sha256:4338d2a81f5b4ca022e085040b3cfce19419a5ce44aa7e6810ac1df05365bed7",
+                "sha256:4c535b46f20e66bee3097583231977e721acdfcb1671d1490c99b7be8902ce18",
+                "sha256:557154aef70a0e979700cc9528bc8b606b668084a29a0d57dbc4b06b078a2f1c",
+                "sha256:5bfdd7e6647498f979dc46583723c852d97b25afe995d55aa1c76a5f9816bc1f",
+                "sha256:87d8943ae7aa6ca5bbad732867d7f17d2550e4966a0c15b52088e8b579422e47",
+                "sha256:89d8719d8de4d137678f7caa979e1b0a6fd4026f8096ceef8c2d164bbabefaf2",
+                "sha256:9c3f4af989ce860710ac1864dc2e867dd87e6cee51a2368df1b253596868e52f",
+                "sha256:9da52c3c728883aee429bb7c315049f50b2139f680cd86bb1165418e4f93a982",
+                "sha256:9e9736659987beab42d18525ed10d21f80a1ba8389eac03425fbfd5684e6bbf0",
+                "sha256:9ebcbb1a054cab362d29d3be571d43d6b9b23302d9fc4b43e5327000da1680a9",
+                "sha256:a93e08636623e24c939851e2e0c0140b14f524b2980c9cdc4ea52b70a871c7e0",
+                "sha256:ac322d86d1a079e0a118d544443ee16f320af0062c191b4754c0c6ec2fc79310",
+                "sha256:b1fb101459868f52df6b61e7bb13375e50badf17a160e39fe1d51ae19e53f461",
+                "sha256:b39aac96cceac624a23d540473835086a3ffa77c91030189988c073488434493",
+                "sha256:b65507bc273c6dbf539175a786a344cc0ac78d50e5584f72c6599733f8a3301f",
+                "sha256:be5bb6e47417e537c884a2e2ff2e1a8b2c064a998fcfdfcc67528d4e63e7ebaf",
+                "sha256:c92de6a28a909c4f460dc1bbbcb50d676cf0b1f40224b222761f73fdd851b522",
+                "sha256:c9f5962eb7fa7607b20eb0e4f59ed35829bd600fc0eacb626a6db83229a3e445",
+                "sha256:d00bdf9c546ed6e649f785c55b05288e8b2dbb6bf2eb74b6c579fa0d591d35bd",
+                "sha256:da804b1dd8293bd9d61b1e6ea989c887ba042a808a4fbdd80001cfa059aafed2",
+                "sha256:ead6c5aa3e807345913649c3be395aaca2bbb2d225f18b8f31f37eab225508f6",
+                "sha256:eb4d81550ce6f826af4ec6e8d98be347fe96291d718bf115c3f254621ae8d98d",
+                "sha256:ef6a18ec8fd32ec81748fe720544ea2fb2d2dc50fd6d06739d5e2eb8f0626a1c",
+                "sha256:fad42835656e0b6d3b7ffc900598e776722e30f43b7234a48f2576ca30f31a47",
+                "sha256:fb98dbfee0d963b49ae5754554028cf62e6bd695f22de16d242ba9d2f0b7339b",
+                "sha256:fb9cd9bb8d26dc17c2dd715a46bca3a879ec8283879b164e85863110dc6e3b2a"
+            ],
+            "version": "==1.21.1"
+        },
+        "h5py": {
+            "hashes": [
+                "sha256:05750b91640273c69989c657eaac34b091abdd75efc8c4824c82aaf898a2da0a",
+                "sha256:082a27208aa3a2286e7272e998e7e225b2a7d4b7821bd840aebf96d50977abbb",
+                "sha256:08e2e8297195f9e813e894b6c63f79372582787795bba2014a2db6a2de95f713",
+                "sha256:0dd2adeb2e9de5081eb8dcec88874e7fd35dae9a21557be3a55a3c7d491842a4",
+                "sha256:0f94de7a10562b991967a66bbe6dda9808e18088676834c0a4dcec3fdd3bcc6f",
+                "sha256:106e42e2e01e486a3d32eeb9ba0e3a7f65c12fa8998d63625fa41fb8bdc44cdb",
+                "sha256:1606c66015f04719c41a9863c156fc0e6b992150de21c067444bcb82e7d75579",
+                "sha256:1854c4beff9961e477e133143c5e5e355dac0b3ebf19c52cf7cc1b1ef757703c",
+                "sha256:1e9fb6f1746500ea91a00193ce2361803c70c6b13f10aae9a33ad7b5bd28e800",
+                "sha256:2cca17e80ddb151894333377675db90cd0279fa454776e0a4f74308376afd050",
+                "sha256:30e365e8408759db3778c361f1e4e0fe8e98a875185ae46c795a85e9bafb9cdf",
+                "sha256:3206bac900e16eda81687d787086f4ffd4f3854980d798e191a9868a6510c3ae",
+                "sha256:3c23d72058647cee19b30452acc7895621e2de0a0bd5b8a1e34204b9ea9ed43c",
+                "sha256:407b5f911a83daa285bbf1ef78a9909ee5957f257d3524b8606be37e8643c5f0",
+                "sha256:4162953714a9212d373ac953c10e3329f1e830d3c7473f2a2e4f25dd6241eef0",
+                "sha256:5fc7aba72a51b2c80605eba1c50dbf84224dcd206279d30a75c154e5652e1fe4",
+                "sha256:713ac19307e11de4d9833af0c4bd6778bde0a3d967cafd2f0f347223711c1e31",
+                "sha256:71b946d80ef3c3f12db157d7778b1fe74a517ca85e94809358b15580983c2ce2",
+                "sha256:8cc4aed71e20d87e0a6f02094d718a95252f11f8ed143bc112d22167f08d4040",
+                "sha256:9d41ca62daf36d6b6515ab8765e4c8c4388ee18e2a665701fef2b41563821002",
+                "sha256:a744e13b000f234cd5a5b2a1f95816b819027c57f385da54ad2b7da1adace2f3",
+                "sha256:b087ee01396c4b34e9dc41e3a6a0442158206d383c19c7d0396d52067b17c1cb",
+                "sha256:b0f03af381d33306ce67d18275b61acb4ca111ced645381387a02c8a5ee1b796",
+                "sha256:b9e4b8dfd587365bdd719ae178fa1b6c1231f81280b1375eef8626dfd8761bf3",
+                "sha256:c5dd4ec75985b99166c045909e10f0534704d102848b1d9f0992720e908928e7",
+                "sha256:d2b82f23cd862a9d05108fe99967e9edfa95c136f532a71cb3d28dc252771f50",
+                "sha256:e58a25764472af07b7e1c4b10b0179c8ea726446c7141076286e41891bf3a563",
+                "sha256:f3b49107fbfc77333fc2b1ef4d5de2abcd57e7ea3a1482455229494cf2da56ce"
+            ],
+            "version": "==2.9.0"
         },
         "importlib-metadata": {
             "hashes": [
@@ -146,12 +285,246 @@
             ],
             "version": "==0.18"
         },
+        "ipykernel": {
+            "hashes": [
+                "sha256:346189536b88859937b5f4848a6fd85d1ad0729f01724a411de5cae9b618819c",
+                "sha256:f0e962052718068ad3b1d8bcc703794660858f58803c3798628817f492a8769c"
+            ],
+            "version": "==5.1.1"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:0806894ae78ddb94b530514acc9ab03a928b79374d8630470b439b58383dd7ee",
+                "sha256:263376e672c7f104fb971c9e1f372441bb34d66dfb7323062f62aa21fa46a377"
+            ],
+            "index": "pypi",
+            "version": "==7.6.0"
+        },
+        "ipython-genutils": {
+            "hashes": [
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+            ],
+            "version": "==0.2.0"
+        },
+        "ipywidgets": {
+            "hashes": [
+                "sha256:0f2b5cde9f272cb49d52f3f0889fdd1a7ae1e74f37b48dac35a83152780d2b7b",
+                "sha256:a3e224f430163f767047ab9a042fc55adbcab0c24bbe6cf9f306c4f89fdf0ba3"
+            ],
+            "version": "==7.4.2"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:49ccb782651bb6f7009810d17a3316f8867dde31654c750506970742e18b553d",
+                "sha256:79d0f6595f3846dffcbe667cc6dc821b96e5baa8add125176c31a3917eb19d58"
+            ],
+            "version": "==0.14.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+            ],
+            "version": "==2.10.1"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:0c0a81564f181de3212efa2d17de1910f8732fa1b71c42266d983cd74304e20d",
+                "sha256:a5f6559964a3851f59040d3b961de5e68e70971afb88ba519d27e6a039efff1a"
+            ],
+            "version": "==3.0.1"
+        },
+        "jupyter": {
+            "hashes": [
+                "sha256:3e1f86076bbb7c8c207829390305a2b1fe836d471ed54be66a3b8c41e7f46cc7",
+                "sha256:5b290f93b98ffbc21c0c7e749f054b3267782166d72fa5e3ed1ed4eaf34a2b78",
+                "sha256:d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
+        "jupyter-client": {
+            "hashes": [
+                "sha256:b5f9cb06105c1d2d30719db5ffb3ea67da60919fb68deaefa583deccd8813551",
+                "sha256:c44411eb1463ed77548bc2d5ec0d744c9b81c4a542d9637c7a52824e2121b987"
+            ],
+            "version": "==5.2.4"
+        },
+        "jupyter-console": {
+            "hashes": [
+                "sha256:308ce876354924fb6c540b41d5d6d08acfc946984bf0c97777c1ddcb42e0b2f5",
+                "sha256:cc80a97a5c389cbd30252ffb5ce7cefd4b66bde98219edd16bf5cb6f84bb3568"
+            ],
+            "version": "==6.0.0"
+        },
+        "jupyter-core": {
+            "hashes": [
+                "sha256:2c6e7c1e9f2ac45b5c2ceea5730bc9008d92fe59d0725eac57b04c0edfba24f7",
+                "sha256:f4fa22d6cf25f34807c995f22d2923693575c70f02557bcbfbe59bd5ec8d8b84"
+            ],
+            "version": "==4.5.0"
+        },
+        "keras": {
+            "hashes": [
+                "sha256:794d0c92c6c4122f1f0fcf3a7bc2f49054c6a54ddbef8d8ffafca62795d760b6",
+                "sha256:90b610a3dbbf6d257b20a079eba3fdf2eed2158f64066a7c6f7227023fd60bc9"
+            ],
+            "index": "pypi",
+            "version": "==2.2.4"
+        },
+        "keras-applications": {
+            "hashes": [
+                "sha256:5579f9a12bcde9748f4a12233925a59b93b73ae6947409ff34aa2ba258189fe5",
+                "sha256:df4323692b8c1174af821bf906f1e442e63fa7589bf0f1230a0b6bdc5a810c95"
+            ],
+            "version": "==1.0.8"
+        },
+        "keras-preprocessing": {
+            "hashes": [
+                "sha256:44aee5f2c4d80c3b29f208359fcb336df80f293a0bb6b1c738da43ca206656fb",
+                "sha256:5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5"
+            ],
+            "version": "==1.1.0"
+        },
+        "keras-rl": {
+            "hashes": [
+                "sha256:7bbbb24c8f4560a03f59fb062a5003da102de033bc8cd7d06b69b4c1b48ec054"
+            ],
+            "index": "pypi",
+            "version": "==0.4.2"
+        },
+        "markdown": {
+            "hashes": [
+                "sha256:2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a",
+                "sha256:56a46ac655704b91e5b7e6326ce43d5ef72411376588afa1dd90e881b83c7e8c"
+            ],
+            "version": "==3.1.1"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+            ],
+            "version": "==1.1.1"
+        },
+        "mistune": {
+            "hashes": [
+                "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e",
+                "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"
+            ],
+            "version": "==0.8.4"
+        },
+        "nbconvert": {
+            "hashes": [
+                "sha256:138381baa41d83584459b5cfecfc38c800ccf1f37d9ddd0bd440783346a4c39c",
+                "sha256:4a978548d8383f6b2cfca4a3b0543afb77bc7cb5a96e8b424337ab58c12da9bc"
+            ],
+            "version": "==5.5.0"
+        },
+        "nbformat": {
+            "hashes": [
+                "sha256:b9a0dbdbd45bb034f4f8893cafd6f652ea08c8c1674ba83f2dc55d3955743b0b",
+                "sha256:f7494ef0df60766b7cabe0a3651556345a963b74dbc16bc7c18479041170d402"
+            ],
+            "version": "==4.4.0"
+        },
+        "notebook": {
+            "hashes": [
+                "sha256:573e0ae650c5d76b18b6e564ba6d21bf321d00847de1d215b418acb64f056eb8",
+                "sha256:f64fa6624d2323fbef6210a621817d6505a45d0d4a9367f1843b20a38a4666ee"
+            ],
+            "version": "==5.7.8"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:0778076e764e146d3078b17c24c4d89e0ecd4ac5401beff8e1c87879043a0633",
+                "sha256:141c7102f20abe6cf0d54c4ced8d565b86df4d3077ba2343b61a6db996cefec7",
+                "sha256:14270a1ee8917d11e7753fb54fc7ffd1934f4d529235beec0b275e2ccf00333b",
+                "sha256:27e11c7a8ec9d5838bc59f809bfa86efc8a4fd02e58960fa9c49d998e14332d5",
+                "sha256:2a04dda79606f3d2f760384c38ccd3d5b9bb79d4c8126b67aff5eb09a253763e",
+                "sha256:3c26010c1b51e1224a3ca6b8df807de6e95128b0908c7e34f190e7775455b0ca",
+                "sha256:52c40f1a4262c896420c6ea1c6fda62cf67070e3947e3307f5562bd783a90336",
+                "sha256:6e4f8d9e8aa79321657079b9ac03f3cf3fd067bf31c1cca4f56d49543f4356a5",
+                "sha256:7242be12a58fec245ee9734e625964b97cf7e3f2f7d016603f9e56660ce479c7",
+                "sha256:7dc253b542bfd4b4eb88d9dbae4ca079e7bf2e2afd819ee18891a43db66c60c7",
+                "sha256:94f5bd885f67bbb25c82d80184abbf7ce4f6c3c3a41fbaa4182f034bba803e69",
+                "sha256:a89e188daa119ffa0d03ce5123dee3f8ffd5115c896c2a9d4f0dbb3d8b95bfa3",
+                "sha256:ad3399da9b0ca36e2f24de72f67ab2854a62e623274607e37e0ce5f5d5fa9166",
+                "sha256:b0348be89275fd1d4c44ffa39530c41a21062f52299b1e3ee7d1c61f060044b8",
+                "sha256:b5554368e4ede1856121b0dfa35ce71768102e4aa55e526cb8de7f374ff78722",
+                "sha256:cbddc56b2502d3f87fda4f98d948eb5b11f36ff3902e17cb6cc44727f2200525",
+                "sha256:d79f18f41751725c56eceab2a886f021d70fd70a6188fd386e29a045945ffc10",
+                "sha256:dc2ca26a19ab32dc475dbad9dfe723d3a64c835f4c23f625c2b6566ca32b9f29",
+                "sha256:dd9bcd4f294eb0633bb33d1a74febdd2b9018b8b8ed325f861fffcd2c7660bb8",
+                "sha256:e8baab1bc7c9152715844f1faca6744f2416929de10d7639ed49555a85549f52",
+                "sha256:ec31fe12668af687b99acf1567399632a7c47b0e17cfb9ae47c098644ef36797",
+                "sha256:f12b4f7e2d8f9da3141564e6737d79016fe5336cc92de6814eba579744f65b0a",
+                "sha256:f58ac38d5ca045a377b3b377c84df8175ab992c970a53332fa8ac2373df44ff7"
+            ],
+            "index": "pypi",
+            "version": "==1.16.4"
+        },
         "packaging": {
             "hashes": [
                 "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
                 "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
             ],
             "version": "==19.0"
+        },
+        "pandocfilters": {
+            "hashes": [
+                "sha256:b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9"
+            ],
+            "version": "==1.4.2"
+        },
+        "parso": {
+            "hashes": [
+                "sha256:5052bb33be034cba784193e74b1cde6ebf29ae8b8c1e4ad94df0c4209bfc4826",
+                "sha256:db5881df1643bf3e66c097bfd8935cf03eae73f4cb61ae4433c9ea4fb6613446"
+            ],
+            "version": "==0.5.0"
+        },
+        "pexpect": {
+            "hashes": [
+                "sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1",
+                "sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.7.0"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
         },
         "pluggy": {
             "hashes": [
@@ -160,12 +533,64 @@
             ],
             "version": "==0.12.0"
         },
+        "prometheus-client": {
+            "hashes": [
+                "sha256:71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da"
+            ],
+            "version": "==0.7.1"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780",
+                "sha256:2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1",
+                "sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55"
+            ],
+            "version": "==2.0.9"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:03f43eac9d5b651f976e91cf46a25b75e5779d98f0f4114b0abfed83376d75f8",
+                "sha256:0c94b21e6de01362f91a86b372555d22a60b59708599ca9d5032ae9fdf8e3538",
+                "sha256:2d2a9f30f61f4063fadd7fb68a2510a6939b43c0d6ceeec5c4704f22225da28e",
+                "sha256:34a0b05fca061e4abb77dd180209f68d8637115ff319f51e28a6a9382d69853a",
+                "sha256:358710fd0db25372edcf1150fa691f48376a134a6c69ce29f38f185eea7699e6",
+                "sha256:41e47198b94c27ba05a08b4a95160656105745c462af574e4bcb0807164065c0",
+                "sha256:8c61cc8a76e9d381c665aecc5105fa0f1878cf7db8b5cd17202603bcb386d0fc",
+                "sha256:a6eebc4db759e58fdac02efcd3028b811effac881d8a5bad1996e4e8ee6acb47",
+                "sha256:a9c12f7c98093da0a46ba76ec40ace725daa1ac4038c41e4b1466afb5c45bb01",
+                "sha256:cb95068492ba0859b8c9e61fa8ba206a83c64e5d0916fb4543700b2e2b214115",
+                "sha256:cd98476ce7bb4dcd6a7b101f5eecdc073dafea19f311e36eb8fba1a349346277",
+                "sha256:ce64cfbea18c535176bdaa10ba740c0fc4c6d998a3f511c17bedb0ae4b3b167c",
+                "sha256:dcbb59eac73fd454e8f2c5fba9e3d3320fd4707ed6a9d3ea3717924a6f0903ea",
+                "sha256:dd67f34458ae716029e2a71ede998e9092493b62a519236ca52e3c5202096c87",
+                "sha256:e3c96056eb5b7284a20e256cb0bf783c8f36ad82a4ae5434a7b7cd02384144a7",
+                "sha256:f612d584d7a27e2f39e7b17878430a959c1bc09a74ba09db096b468558e5e126",
+                "sha256:f6de8a7d6122297b81566e5bd4df37fd5d62bec14f8f90ebff8ede1c9726cd0a",
+                "sha256:fa529d9261682b24c2aaa683667253175c9acebe0a31105394b221090da75832"
+            ],
+            "version": "==3.8.0"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "markers": "os_name != 'nt'",
+            "version": "==0.6.0"
+        },
         "py": {
             "hashes": [
                 "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
                 "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
             "version": "==1.8.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
+                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
+            ],
+            "version": "==2.4.2"
         },
         "pyparsing": {
             "hashes": [
@@ -174,6 +599,101 @@
             ],
             "version": "==2.4.0"
         },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:16692ee739d42cf5e39cef8d27649a8c1fdb7aa99887098f1460057c5eb75c3a",
+                "sha256:5423297b7c6bd4c97eef8157764eb95e3897d1eccd0268cc5c50cb25ab5cb2b2"
+            ],
+            "version": "==0.15.2"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "version": "==2.8.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:57acc1d8533cbe51f6662a55434f0dbecfa2b9eaf115bede8f6fd00115a0c0d3",
+                "sha256:588c94b3d16b76cfed8e0be54932e5729cc185caffaa5a451e7ad2f7ed8b4043",
+                "sha256:68c8dd247f29f9a0d09375c9c6b8fdc64b60810ebf07ba4cdd64ceee3a58c7b7",
+                "sha256:70d9818f1c9cd5c48bb87804f2efc8692f1023dac7f1a1a5c61d454043c1d265",
+                "sha256:86a93cccd50f8c125286e637328ff4eef108400dd7089b46a7be3445eecfa391",
+                "sha256:a0f329125a926876f647c9fa0ef32801587a12328b4a3c741270464e3e4fa778",
+                "sha256:a3c252ab0fa1bb0d5a3f6449a4826732f3eb6c0270925548cac342bc9b22c225",
+                "sha256:b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab7f3ac2770955",
+                "sha256:cd0618c5ba5bda5f4039b9398bb7fb6a317bb8298218c3de25c47c4740e4b95e",
+                "sha256:ceacb9e5f8474dcf45b940578591c7f3d960e82f926c707788a570b51ba59190",
+                "sha256:fe6a88094b64132c4bb3b631412e90032e8cfe9745a58370462240b8cb7553cd"
+            ],
+            "version": "==5.1.1"
+        },
+        "pyzmq": {
+            "hashes": [
+                "sha256:00dd015159eaeb1c0731ad49310e1f5d839c9a35a15e4f3267f5052233fad99b",
+                "sha256:03913b6beb8e7b417b9910b0ee1fd5d62e9626d218faefbe879d70714ceab1a2",
+                "sha256:13f17386df81d5e6efb9a4faea341d8de22cdc82e49a326dded26e33f42a3112",
+                "sha256:16c6281d96885db1e15f7047ddc1a8f48ff4ea35d31ca709f4d2eb39f246d356",
+                "sha256:17efab4a804e31f58361631256d660214204046f9e2b962738b171b9ad674ea7",
+                "sha256:2b79919ddeff3d3c96aa6087c21d294c8db1c01f6bfeee73324944683685f419",
+                "sha256:2f832e4711657bb8d16ea1feba860f676ec5f14fb9fe3b449b5953a60e89edae",
+                "sha256:31a11d37ac73107363b47e14c94547dbfc6a550029c3fe0530be443199026fc2",
+                "sha256:33a3e928e6c3138c675e1d6702dd11f6b7050177d7aab3fc322db6e1d2274490",
+                "sha256:34a38195a6d3a9646cbcdaf8eb245b4d935c7a57f7e1b3af467814bc1a92467e",
+                "sha256:42900054f1500acef6df7428edf806abbf641bf92eb9ceded24aa863397c3bae",
+                "sha256:4ccc7f3c63aa9d744dadb62c49eda2d0e7de55649b80c45d7c684d70161a69af",
+                "sha256:5b220c37c346e6575db8c88a940c1fc234f99ce8e0068c408919bb8896c4b6d2",
+                "sha256:6074848da5c8b44a1ca40adf75cf65aa92bc80f635e8249aa8f37a69b2b9b6f5",
+                "sha256:61a4155964bd4a14ef95bf46cb1651bcf8dcbbed8c0108e9c974c1fcbb57788f",
+                "sha256:62b5774688326600c52f587f7a033ca6b6284bef4c8b1b5fda32480897759eac",
+                "sha256:65a9ffa4f9f085d696f16fd7541f34b3c357d25fe99c90e3bce2ea59c3b5b4b6",
+                "sha256:76a077d2c30f8adc5e919a55985a784b96aeca69b53c1ea6fd5723d3ae2e6f53",
+                "sha256:8e5b4c51557071d6379d6dc1f54f35e9f6a137f5e84e102efb869c8d3c13c8ff",
+                "sha256:917f73e07cc04f0678a96d93e7bb8b1adcccdde9ccfe202e622814f4d1d1ecfd",
+                "sha256:91c75d3c4c357f9643e739db9e79ab9681b2f6ae8ec5678d6ef2ea0d01532596",
+                "sha256:923dd91618b100bb4c92ab9ed7b65825a595b8524a094ce03c7cb2aaae7d353b",
+                "sha256:9849054e0355e2bc7f4668766a25517ba76095031c9ff5e39ae8949cee5bb024",
+                "sha256:c9d453933f0e3f44b9759189f2a18aa765f7f1a4345c727c18ebe8ad0d748d26",
+                "sha256:cb7514936277abce64c2f4c56883e5704d85ed04d98d2d432d1c6764003bb003"
+            ],
+            "version": "==18.0.2"
+        },
+        "qtconsole": {
+            "hashes": [
+                "sha256:4af84facdd6f00a6b9b2927255f717bb23ae4b7a20ba1d9ef0a5a5a8dbe01ae2",
+                "sha256:60d61d93f7d67ba2b265c6d599d413ffec21202fec999a952f658ff3a73d252b"
+            ],
+            "version": "==4.5.1"
+        },
+        "scipy": {
+            "hashes": [
+                "sha256:03b1e0775edbe6a4c64effb05fff2ce1429b76d29d754aa5ee2d848b60033351",
+                "sha256:09d008237baabf52a5d4f5a6fcf9b3c03408f3f61a69c404472a16861a73917e",
+                "sha256:10325f0ffac2400b1ec09537b7e403419dcd25d9fee602a44e8a32119af9079e",
+                "sha256:1db9f964ed9c52dc5bd6127f0dd90ac89791daa690a5665cc01eae185912e1ba",
+                "sha256:409846be9d6bdcbd78b9e5afe2f64b2da5a923dd7c1cd0615ce589489533fdbb",
+                "sha256:4907040f62b91c2e170359c3d36c000af783f0fa1516a83d6c1517cde0af5340",
+                "sha256:6c0543f2fdd38dee631fb023c0f31c284a532d205590b393d72009c14847f5b1",
+                "sha256:826b9f5fbb7f908a13aa1efd4b7321e36992f5868d5d8311c7b40cf9b11ca0e7",
+                "sha256:a7695a378c2ce402405ea37b12c7a338a8755e081869bd6b95858893ceb617ae",
+                "sha256:a84c31e8409b420c3ca57fd30c7589378d6fdc8d155d866a7f8e6e80dec6fd06",
+                "sha256:adadeeae5500de0da2b9e8dd478520d0a9945b577b2198f2462555e68f58e7ef",
+                "sha256:b283a76a83fe463c9587a2c88003f800e08c3929dfbeba833b78260f9c209785",
+                "sha256:c19a7389ab3cd712058a8c3c9ffd8d27a57f3d84b9c91a931f542682bb3d269d",
+                "sha256:c3bb4bd2aca82fb498247deeac12265921fe231502a6bc6edea3ee7fe6c40a7a",
+                "sha256:c5ea60ece0c0c1c849025bfc541b60a6751b491b6f11dd9ef37ab5b8c9041921",
+                "sha256:db61a640ca20f237317d27bc658c1fc54c7581ff7f6502d112922dc285bdabee"
+            ],
+            "version": "==1.3.0"
+        },
+        "send2trash": {
+            "hashes": [
+                "sha256:60001cc07d707fe247c94f74ca6ac0d3255aabcb930529690897ca2a39db28b2",
+                "sha256:f1691922577b6fa12821234aeb57599d887c4900b9ca537948d2dac34aea888b"
+            ],
+            "version": "==1.5.0"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
@@ -181,12 +701,72 @@
             ],
             "version": "==1.12.0"
         },
+        "tensorboard": {
+            "hashes": [
+                "sha256:50e0b1bdcd488dbe39fd9416976e089b2ff4df18d9f1fab47abf4c498209c3fc",
+                "sha256:c35ba681a52d4922be6b225623cf77285033e7e4e68bac5c1d5490e47d129bb2"
+            ],
+            "version": "==1.14.0"
+        },
+        "tensorflow-estimator": {
+            "hashes": [
+                "sha256:ca073f66063407a091d610ec1b22e39ea30248710198cc6f13769320bdbe3992"
+            ],
+            "version": "==1.14.0"
+        },
+        "tensorflow-gpu": {
+            "hashes": [
+                "sha256:043dc9b66500feceb9d4857940ff50cc7ed40b588d47c129d57625191a6ae077",
+                "sha256:1b7ce8d3b22112f5d3b0389e7bd13761ce6a801f1899af7858b6bd95563fc1d6",
+                "sha256:45e0213a7681feb7bfa19208d640794f53f7b5c30c1061e5be43a7f938edbf6e",
+                "sha256:6c2621ceb0a3b59606a06c5193f967243a6ebbd41c001d81231e77fc66266a7e",
+                "sha256:71ab378b22ffb457cffeb01d48a31ba00cf90a8cea1ab18b84bd0efe0f207d7d",
+                "sha256:8563b56388f6e9efdca10fcea2c9f6f03b3e4c65cd22fa5a93d73caf5e483d78",
+                "sha256:a2528c9ab069599b7c6f9f2f1f751bcb5467b49a4960580a225d7b612dba396e",
+                "sha256:bd8efeb415dcc353d501510ed3bbe1c4b996e5c05797b444455d86bfee7bf10e",
+                "sha256:ed8db7cbf95f56fff7e7baa73a0912a63a46887b38ac19bdd75941e818baf37a"
+            ],
+            "index": "pypi",
+            "version": "==1.14.0"
+        },
+        "termcolor": {
+            "hashes": [
+                "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
+            ],
+            "version": "==1.1.0"
+        },
+        "terminado": {
+            "hashes": [
+                "sha256:d9d012de63acb8223ac969c17c3043337c2fcfd28f3aea1ee429b345d01ef460",
+                "sha256:de08e141f83c3a0798b050ecb097ab6259c3f0331b2f7b7750c9075ced2c20c2"
+            ],
+            "version": "==0.8.2"
+        },
+        "testpath": {
+            "hashes": [
+                "sha256:46c89ebb683f473ffe2aab0ed9f12581d4d078308a3cb3765d79c6b2317b0109",
+                "sha256:b694b3d9288dbd81685c5d2e7140b81365d46c29f5db4bc659de5aa6b98780f8"
+            ],
+            "version": "==0.4.2"
+        },
         "toml": {
             "hashes": [
                 "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+        },
+        "tornado": {
+            "hashes": [
+                "sha256:349884248c36801afa19e342a77cc4458caca694b0eda633f5878e458a44cb2c",
+                "sha256:398e0d35e086ba38a0427c3b37f4337327231942e731edaa6e9fd1865bbd6f60",
+                "sha256:4e73ef678b1a859f0cb29e1d895526a20ea64b5ffd510a2307b5998c7df24281",
+                "sha256:559bce3d31484b665259f50cd94c5c28b961b09315ccd838f284687245f416e5",
+                "sha256:abbe53a39734ef4aba061fca54e30c6b4639d3e1f59653f0da37a0003de148c7",
+                "sha256:c845db36ba616912074c5b1ee897f8e0124df269468f25e4fe21fe72f6edd7a9",
+                "sha256:c9399267c926a4e7c418baa5cbe91c7d1cf362d505a1ef898fde44a07c9dd8a5"
+            ],
+            "version": "==6.0.3"
         },
         "tox": {
             "hashes": [
@@ -196,12 +776,61 @@
             "index": "pypi",
             "version": "==3.13.1"
         },
+        "traitlets": {
+            "hashes": [
+                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
+                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
+            ],
+            "version": "==4.3.2"
+        },
         "virtualenv": {
             "hashes": [
                 "sha256:b7335cddd9260a3dd214b73a2521ffc09647bde3e9457fcca31dc3be3999d04a",
                 "sha256:d28ca64c0f3f125f59cabf13e0a150e1c68e5eea60983cc4395d88c584495783"
             ],
             "version": "==16.6.1"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:865856ebb55c4dcd0630cdd8f3331a1847a819dda7e8c750d3db6f2aa6c0209c",
+                "sha256:a0b915f0815982fb2a09161cb8f31708052d0951c3ba433ccc5e1aa276507ca6"
+            ],
+            "version": "==0.15.4"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:5e79117472686ac0c4aef5bad5172ea73a1c2d1646b808c35926bd26bdfb0c08",
+                "sha256:62fcfa03d45b5b722539ccbc07b190e4bfff4bb9e3a4d470dd9f6a0981002565"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==0.33.4"
+        },
+        "widgetsnbextension": {
+            "hashes": [
+                "sha256:14b2c65f9940c9a7d3b70adbe713dbd38b5ec69724eebaba034d1036cf3d4740",
+                "sha256:fa618be8435447a017fd1bf2c7ae922d0428056cfc7449f7a8641edf76b48265"
+            ],
+            "version": "==3.4.2"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+            ],
+            "version": "==1.11.2"
         },
         "zipp": {
             "hashes": [

--- a/examples/breakout_n.ipynb
+++ b/examples/breakout_n.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Learn to play at Breakout \n",
+    "\n",
+    "### Requirements\n",
+    "\n",
+    "- [install `keras-rl`](https://github.com/keras-rl/keras-rl#installation)\n",
+    "\n",
+    "      pip install keras-rl\n",
+    "      \n",
+    "- install the `gym_breakout_pygame` package\n",
+    "\n",
+    "      pip install gym_breakout_pygame\n",
+    "      "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pygame 1.9.6\n",
+      "Hello from the pygame community. https://www.pygame.org/contribute.html\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow backend.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import gym\n",
+    "from gym_breakout_pygame.wrappers.observation_space import BreakoutN\n",
+    "\n",
+    "from keras.models import Sequential\n",
+    "from keras.layers import Dense, Activation, Flatten\n",
+    "from keras.optimizers import Adam\n",
+    "\n",
+    "from rl.agents.dqn import DQNAgent\n",
+    "from rl.policy import BoltzmannQPolicy\n",
+    "from rl.memory import SequentialMemory\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Logging before flag parsing goes to stderr.\n",
+      "W0629 23:48:49.540298 140024841986176 deprecation_wrapper.py:119] From /home/marcofavorito/.virtualenvs/gym-breakout-pygame-7UQzWS9l/lib/python3.7/site-packages/keras/backend/tensorflow_backend.py:74: The name tf.get_default_graph is deprecated. Please use tf.compat.v1.get_default_graph instead.\n",
+      "\n",
+      "W0629 23:48:49.551870 140024841986176 deprecation_wrapper.py:119] From /home/marcofavorito/.virtualenvs/gym-breakout-pygame-7UQzWS9l/lib/python3.7/site-packages/keras/backend/tensorflow_backend.py:517: The name tf.placeholder is deprecated. Please use tf.compat.v1.placeholder instead.\n",
+      "\n",
+      "W0629 23:48:49.561582 140024841986176 deprecation_wrapper.py:119] From /home/marcofavorito/.virtualenvs/gym-breakout-pygame-7UQzWS9l/lib/python3.7/site-packages/keras/backend/tensorflow_backend.py:4138: The name tf.random_uniform is deprecated. Please use tf.random.uniform instead.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "flatten_1 (Flatten)          (None, 4)                 0         \n",
+      "_________________________________________________________________\n",
+      "dense_1 (Dense)              (None, 64)                320       \n",
+      "_________________________________________________________________\n",
+      "activation_1 (Activation)    (None, 64)                0         \n",
+      "_________________________________________________________________\n",
+      "dense_2 (Dense)              (None, 64)                4160      \n",
+      "_________________________________________________________________\n",
+      "activation_2 (Activation)    (None, 64)                0         \n",
+      "_________________________________________________________________\n",
+      "dense_3 (Dense)              (None, 3)                 195       \n",
+      "_________________________________________________________________\n",
+      "activation_3 (Activation)    (None, 3)                 0         \n",
+      "=================================================================\n",
+      "Total params: 4,675\n",
+      "Trainable params: 4,675\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n",
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "env = BreakoutN(encode=False)\n",
+    "np.random.seed(123)\n",
+    "env.seed(123)\n",
+    "nb_actions = env.action_space.n\n",
+    "\n",
+    "# Next, we build a very simple model.\n",
+    "model = Sequential()\n",
+    "model.add(Flatten(input_shape=(1,) + env.observation_space.shape))\n",
+    "model.add(Dense(64))\n",
+    "model.add(Activation('relu'))\n",
+    "model.add(Dense(64))\n",
+    "model.add(Activation('relu'))\n",
+    "model.add(Dense(nb_actions))\n",
+    "model.add(Activation('linear'))\n",
+    "print(model.summary())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training for 10000 steps ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/marcofavorito/.virtualenvs/gym-breakout-pygame-7UQzWS9l/lib/python3.7/site-packages/rl/memory.py:39: UserWarning: Not enough entries to sample without replacement. Consider increasing your warm-up phase to avoid oversampling!\n",
+      "  warnings.warn('Not enough entries to sample without replacement. Consider increasing your warm-up phase to avoid oversampling!')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  151/10000: episode: 1, duration: 1.291s, episode steps: 151, steps per second: 117, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.265 [0.000, 2.000], mean observation: 12.472 [0.000, 47.000], loss: 0.139938, mean_absolute_error: 6.834894, mean_q: 10.322103\n",
+      "  302/10000: episode: 2, duration: 0.695s, episode steps: 151, steps per second: 217, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.212 [0.000, 2.000], mean observation: 13.139 [2.000, 47.000], loss: 0.302389, mean_absolute_error: 6.738727, mean_q: 10.205843\n",
+      "  453/10000: episode: 3, duration: 0.721s, episode steps: 151, steps per second: 209, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.166 [0.000, 2.000], mean observation: 12.513 [0.000, 47.000], loss: 0.212746, mean_absolute_error: 6.262754, mean_q: 9.478497\n",
+      " 1004/10000: episode: 4, duration: 2.522s, episode steps: 551, steps per second: 218, episode reward: 20.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.103 [0.000, 2.000], mean observation: 11.964 [0.000, 47.000], loss: 0.162617, mean_absolute_error: 6.349705, mean_q: 9.591459\n",
+      " 1157/10000: episode: 5, duration: 0.723s, episode steps: 153, steps per second: 212, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 0.961 [0.000, 2.000], mean observation: 11.312 [0.000, 47.000], loss: 0.118096, mean_absolute_error: 6.336495, mean_q: 9.563386\n",
+      " 1450/10000: episode: 6, duration: 1.350s, episode steps: 293, steps per second: 217, episode reward: 10.000, mean reward: 0.034 [0.000, 5.000], mean action: 1.061 [0.000, 2.000], mean observation: 12.223 [0.000, 47.000], loss: 0.164441, mean_absolute_error: 6.255363, mean_q: 9.436339\n",
+      " 1731/10000: episode: 7, duration: 1.526s, episode steps: 281, steps per second: 184, episode reward: 10.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.085 [0.000, 2.000], mean observation: 11.957 [0.000, 47.000], loss: 0.130119, mean_absolute_error: 6.211799, mean_q: 9.367690\n",
+      " 2012/10000: episode: 8, duration: 1.468s, episode steps: 281, steps per second: 191, episode reward: 10.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.032 [0.000, 2.000], mean observation: 11.854 [0.000, 47.000], loss: 0.101282, mean_absolute_error: 6.265144, mean_q: 9.460344\n",
+      " 2163/10000: episode: 9, duration: 0.840s, episode steps: 151, steps per second: 180, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.013 [0.000, 2.000], mean observation: 13.290 [2.000, 47.000], loss: 0.116807, mean_absolute_error: 6.227260, mean_q: 9.394555\n",
+      " 2444/10000: episode: 10, duration: 1.287s, episode steps: 281, steps per second: 218, episode reward: 10.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.153 [0.000, 2.000], mean observation: 12.165 [0.000, 47.000], loss: 0.112518, mean_absolute_error: 6.239196, mean_q: 9.404257\n",
+      " 2595/10000: episode: 11, duration: 0.688s, episode steps: 151, steps per second: 219, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 0.987 [0.000, 2.000], mean observation: 12.182 [0.000, 47.000], loss: 0.098400, mean_absolute_error: 6.239956, mean_q: 9.403274\n",
+      " 2750/10000: episode: 12, duration: 0.738s, episode steps: 155, steps per second: 210, episode reward: 5.000, mean reward: 0.032 [0.000, 5.000], mean action: 1.013 [0.000, 2.000], mean observation: 11.458 [0.000, 47.000], loss: 0.119360, mean_absolute_error: 6.203455, mean_q: 9.348826\n",
+      " 2901/10000: episode: 13, duration: 0.684s, episode steps: 151, steps per second: 221, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.053 [0.000, 2.000], mean observation: 13.316 [2.000, 47.000], loss: 0.132499, mean_absolute_error: 6.177451, mean_q: 9.296888\n",
+      " 3052/10000: episode: 14, duration: 0.677s, episode steps: 151, steps per second: 223, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.073 [0.000, 2.000], mean observation: 12.808 [2.000, 47.000], loss: 0.131417, mean_absolute_error: 6.167523, mean_q: 9.279727\n",
+      " 3333/10000: episode: 15, duration: 1.241s, episode steps: 281, steps per second: 226, episode reward: 10.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.004 [0.000, 2.000], mean observation: 12.032 [0.000, 47.000], loss: 0.101450, mean_absolute_error: 6.130254, mean_q: 9.222728\n",
+      " 3484/10000: episode: 16, duration: 0.668s, episode steps: 151, steps per second: 226, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.046 [0.000, 2.000], mean observation: 11.407 [0.000, 47.000], loss: 0.093532, mean_absolute_error: 6.100651, mean_q: 9.184969\n",
+      " 3635/10000: episode: 17, duration: 0.694s, episode steps: 151, steps per second: 217, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.026 [0.000, 2.000], mean observation: 12.525 [2.000, 47.000], loss: 0.090318, mean_absolute_error: 6.032917, mean_q: 9.085444\n",
+      " 4056/10000: episode: 18, duration: 2.196s, episode steps: 421, steps per second: 192, episode reward: 15.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.021 [0.000, 2.000], mean observation: 11.898 [0.000, 47.000], loss: 0.094593, mean_absolute_error: 6.026717, mean_q: 9.057995\n",
+      " 4207/10000: episode: 19, duration: 0.795s, episode steps: 151, steps per second: 190, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.000 [0.000, 2.000], mean observation: 12.768 [2.000, 47.000], loss: 0.098942, mean_absolute_error: 5.987989, mean_q: 8.992657\n",
+      " 5048/10000: episode: 20, duration: 3.818s, episode steps: 841, steps per second: 220, episode reward: 40.000, mean reward: 0.048 [0.000, 5.000], mean action: 0.992 [0.000, 2.000], mean observation: 11.447 [0.000, 47.000], loss: 0.106548, mean_absolute_error: 5.981682, mean_q: 8.972653\n",
+      " 5597/10000: episode: 21, duration: 3.344s, episode steps: 549, steps per second: 164, episode reward: 20.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.031 [0.000, 2.000], mean observation: 10.914 [0.000, 47.000], loss: 0.117000, mean_absolute_error: 5.878624, mean_q: 8.812840\n",
+      " 5748/10000: episode: 22, duration: 0.721s, episode steps: 151, steps per second: 209, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 0.993 [0.000, 2.000], mean observation: 13.192 [2.000, 47.000], loss: 0.101925, mean_absolute_error: 5.860528, mean_q: 8.786705\n",
+      " 5899/10000: episode: 23, duration: 0.754s, episode steps: 151, steps per second: 200, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.040 [0.000, 2.000], mean observation: 12.106 [0.000, 47.000], loss: 0.090772, mean_absolute_error: 5.861043, mean_q: 8.784028\n",
+      " 6180/10000: episode: 24, duration: 1.633s, episode steps: 281, steps per second: 172, episode reward: 10.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.021 [0.000, 2.000], mean observation: 12.096 [0.000, 47.000], loss: 0.103209, mean_absolute_error: 5.884806, mean_q: 8.824003\n",
+      " 6605/10000: episode: 25, duration: 2.420s, episode steps: 425, steps per second: 176, episode reward: 15.000, mean reward: 0.035 [0.000, 5.000], mean action: 1.068 [0.000, 2.000], mean observation: 11.667 [0.000, 47.000], loss: 0.128892, mean_absolute_error: 5.890673, mean_q: 8.830324\n",
+      " 6886/10000: episode: 26, duration: 1.580s, episode steps: 281, steps per second: 178, episode reward: 10.000, mean reward: 0.036 [0.000, 5.000], mean action: 1.000 [0.000, 2.000], mean observation: 11.687 [0.000, 47.000], loss: 0.107655, mean_absolute_error: 5.881782, mean_q: 8.810139\n",
+      " 7037/10000: episode: 27, duration: 1.005s, episode steps: 151, steps per second: 150, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.060 [0.000, 2.000], mean observation: 13.344 [2.000, 47.000], loss: 0.108550, mean_absolute_error: 5.872868, mean_q: 8.803463\n",
+      " 7318/10000: episode: 28, duration: 1.550s, episode steps: 281, steps per second: 181, episode reward: 10.000, mean reward: 0.036 [0.000, 5.000], mean action: 0.975 [0.000, 2.000], mean observation: 11.888 [0.000, 47.000], loss: 0.103449, mean_absolute_error: 5.845335, mean_q: 8.754951\n",
+      " 7469/10000: episode: 29, duration: 0.808s, episode steps: 151, steps per second: 187, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.020 [0.000, 2.000], mean observation: 11.863 [0.000, 47.000], loss: 0.083441, mean_absolute_error: 5.814384, mean_q: 8.722053\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 7620/10000: episode: 30, duration: 0.839s, episode steps: 151, steps per second: 180, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 0.940 [0.000, 2.000], mean observation: 12.500 [0.000, 47.000], loss: 0.099431, mean_absolute_error: 5.778156, mean_q: 8.661280\n",
+      " 7771/10000: episode: 31, duration: 1.003s, episode steps: 151, steps per second: 151, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.026 [0.000, 2.000], mean observation: 12.709 [2.000, 47.000], loss: 0.099584, mean_absolute_error: 5.764544, mean_q: 8.633820\n",
+      " 7924/10000: episode: 32, duration: 0.724s, episode steps: 153, steps per second: 211, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 0.876 [0.000, 2.000], mean observation: 11.891 [0.000, 47.000], loss: 0.096048, mean_absolute_error: 5.745294, mean_q: 8.614525\n",
+      " 8213/10000: episode: 33, duration: 1.584s, episode steps: 289, steps per second: 182, episode reward: 10.000, mean reward: 0.035 [0.000, 5.000], mean action: 1.031 [0.000, 2.000], mean observation: 11.664 [0.000, 47.000], loss: 0.095409, mean_absolute_error: 5.717917, mean_q: 8.570756\n",
+      " 8364/10000: episode: 34, duration: 0.697s, episode steps: 151, steps per second: 217, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.079 [0.000, 2.000], mean observation: 13.061 [2.000, 47.000], loss: 0.108151, mean_absolute_error: 5.703171, mean_q: 8.525340\n",
+      " 8653/10000: episode: 35, duration: 1.346s, episode steps: 289, steps per second: 215, episode reward: 10.000, mean reward: 0.035 [0.000, 5.000], mean action: 0.917 [0.000, 2.000], mean observation: 11.922 [0.000, 47.000], loss: 0.087449, mean_absolute_error: 5.636314, mean_q: 8.450624\n",
+      " 9204/10000: episode: 36, duration: 2.437s, episode steps: 551, steps per second: 226, episode reward: 20.000, mean reward: 0.036 [0.000, 5.000], mean action: 0.998 [0.000, 2.000], mean observation: 11.618 [0.000, 47.000], loss: 0.096901, mean_absolute_error: 5.612289, mean_q: 8.402783\n",
+      " 9497/10000: episode: 37, duration: 1.284s, episode steps: 293, steps per second: 228, episode reward: 10.000, mean reward: 0.034 [0.000, 5.000], mean action: 1.034 [0.000, 2.000], mean observation: 12.416 [0.000, 47.000], loss: 0.093725, mean_absolute_error: 5.538491, mean_q: 8.294374\n",
+      " 9648/10000: episode: 38, duration: 0.670s, episode steps: 151, steps per second: 225, episode reward: 5.000, mean reward: 0.033 [0.000, 5.000], mean action: 1.073 [0.000, 2.000], mean observation: 13.331 [2.000, 47.000], loss: 0.075202, mean_absolute_error: 5.502677, mean_q: 8.248979\n",
+      " 9937/10000: episode: 39, duration: 1.321s, episode steps: 289, steps per second: 219, episode reward: 10.000, mean reward: 0.035 [0.000, 5.000], mean action: 0.927 [0.000, 2.000], mean observation: 11.962 [0.000, 47.000], loss: 0.089443, mean_absolute_error: 5.464530, mean_q: 8.180284\n",
+      "done, took 50.666 seconds\n",
+      "Testing for 5 episodes ...\n",
+      "Episode 1: reward: 15.000, steps: 419\n",
+      "Episode 2: reward: 15.000, steps: 419\n",
+      "Episode 3: reward: 15.000, steps: 419\n",
+      "Episode 4: reward: 15.000, steps: 419\n",
+      "Episode 5: reward: 15.000, steps: 419\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<keras.callbacks.History at 0x7f59802d95f8>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Configure and compile the RL agent\n",
+    "memory = SequentialMemory(limit=50000, window_length=1)\n",
+    "policy = BoltzmannQPolicy()\n",
+    "dqn = DQNAgent(model=model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=10,\n",
+    "               target_model_update=1e-2, policy=policy)\n",
+    "dqn.compile(Adam(lr=1e-3), metrics=['mae'])\n",
+    "\n",
+    "# learn\n",
+    "dqn.fit(env, nb_steps=30000, visualize=False, verbose=2)\n",
+    "\n",
+    "# save \n",
+    "dqn.save_weights('dqn_{}_weights.h5f'.format(\"breakout-n\"), overwrite=True)\n",
+    "\n",
+    "# Finally, evaluate our algorithm for 5 episodes.\n",
+    "dqn.test(env, nb_episodes=5, visualize=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/gym_breakout_pygame/breakout_env.py
+++ b/gym_breakout_pygame/breakout_env.py
@@ -449,7 +449,7 @@ class Breakout(gym.Env):
         reward = self.state.step()
         state = self.state.observe()
         is_finished = self.state.is_finished()
-        info = None
+        info = {}
         return state, reward, is_finished, info
 
     def reset(self):

--- a/gym_breakout_pygame/breakout_env.py
+++ b/gym_breakout_pygame/breakout_env.py
@@ -1,10 +1,6 @@
 """
-A Q-learning Agent which plays breakout well (won't lose).
-from https://github.com/lincerely/breakout-Q
-
 The breakout game is based on CoderDojoSV/beginner-python's tutorial
 
-Adapted and updated for teaching purposes
 Luca Iocchi 2017
 """
 import math
@@ -16,7 +12,6 @@ from typing import Optional, Set, Tuple, Dict
 import gym
 import numpy as np
 import pygame
-from gym import Space
 from gym.spaces import Dict as DictSpace, Discrete, MultiDiscrete
 
 Position = Tuple[int, int]

--- a/gym_breakout_pygame/breakout_env.py
+++ b/gym_breakout_pygame/breakout_env.py
@@ -331,8 +331,8 @@ class State(object):
 
     def observe(self) -> Dict:
         """Extract the state observation based on the game configuration."""
-        ball_x = int(self.ball.x) / self.config.resolution_x
-        ball_y = int(self.ball.y) / self.config.resolution_y
+        ball_x = int(self.ball.x) // self.config.resolution_x
+        ball_y = int(self.ball.y) // self.config.resolution_y
 
         ball_dir = 0
         if self.ball.speed_y > 0:  # down
@@ -346,7 +346,7 @@ class State(object):
         elif self.ball.speed_x > 0:  # right
             ball_dir += 4
 
-        paddle_x = int(self.paddle.x) / self.config.resolution_x
+        paddle_x = int(self.paddle.x) // self.config.resolution_x
         bricks_matrix = self.brick_grid.bricksgrid.flatten()
 
         return {
@@ -438,9 +438,7 @@ class Breakout(gym.Env):
         self.state = State(self.config)
         self.viewer = None  # type: Optional[PygameViewer]
 
-    @property
-    def observation_space(self) -> Space:
-        return DictSpace({
+        self.observation_space = DictSpace({
             "ball_x": Discrete(self.config.n_ball_x),
             "ball_y": Discrete(self.config.n_ball_y),
             "ball_dir": Discrete(self.config.n_ball_dir),
@@ -448,9 +446,7 @@ class Breakout(gym.Env):
             "bricks_matrix": MultiDiscrete([2] * self.config.brick_cols * self.config.brick_rows)
         })
 
-    @property
-    def action_space(self) -> Space:
-        return Discrete(len(Command))
+        self.action_space = Discrete(len(Command))
 
     def step(self, action: int):
         command = Command(action)
@@ -483,7 +479,6 @@ if __name__ == '__main__':
     env = Breakout(config)
     env.reset()
     env.render(mode="human")
-    input()
     done = False
     while not done:
         time.sleep(0.01)

--- a/gym_breakout_pygame/utils.py
+++ b/gym_breakout_pygame/utils.py
@@ -6,7 +6,7 @@ from typing import List
 from gym.spaces import Dict, Discrete
 
 
-def encode(obs: List[int], spaces: List[Discrete]) -> int:
+def encode(obs: List[int], spaces: List[int]) -> int:
     """
     Encode an observation from a list of gym.Discrete spaces in one number.
     :param obs: an observation belonging to the state space (a list of gym.Discrete spaces)
@@ -14,7 +14,7 @@ def encode(obs: List[int], spaces: List[Discrete]) -> int:
     :return: the encoded observation.
     """
     assert len(obs) == len(spaces)
-    sizes = [s.n for s in spaces]
+    sizes = spaces
     result = obs[0]
     shift = sizes[0]
     for o, size in list(zip(obs, sizes))[1:]:
@@ -24,7 +24,7 @@ def encode(obs: List[int], spaces: List[Discrete]) -> int:
     return result
 
 
-def decode(obs: int, spaces: List[Discrete]) -> List[int]:
+def decode(obs: int, spaces: List[int]) -> List[int]:
     """
     Decode an observation from a list of gym.Discrete spaces in a list of integers.
     It assumes that obs has been encoded by using the 'utils.encode' function.
@@ -33,7 +33,7 @@ def decode(obs: int, spaces: List[Discrete]) -> List[int]:
     :return: the decoded observation.
     """
     result = []
-    sizes = [s.n for s in spaces][::-1]
+    sizes = spaces[::-1]
     shift = reduce(lambda x, y: x*y, sizes) // sizes[0]
     for size in sizes[1:]:
         r = obs // shift

--- a/gym_breakout_pygame/utils.py
+++ b/gym_breakout_pygame/utils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""This module contains utility functions."""
+from functools import reduce
+from typing import List
+
+from gym.spaces import Dict, Discrete
+
+
+def encode(obs: List[int], spaces: List[Discrete]) -> int:
+    """
+    Encode an observation from a list of gym.Discrete spaces in one number.
+    :param obs: an observation belonging to the state space (a list of gym.Discrete spaces)
+    :param spaces: the list of gym.Discrete spaces from where the observation is observed.
+    :return: the encoded observation.
+    """
+    assert len(obs) == len(spaces)
+    sizes = [s.n for s in spaces]
+    result = obs[0]
+    shift = sizes[0]
+    for o, size in list(zip(obs, sizes))[1:]:
+        result += o * shift
+        shift *= size
+
+    return result
+
+
+def decode(obs: int, spaces: List[Discrete]) -> List[int]:
+    """
+    Decode an observation from a list of gym.Discrete spaces in a list of integers.
+    It assumes that obs has been encoded by using the 'utils.encode' function.
+    :param obs: the encoded observation
+    :param spaces: the list of gym.Discrete spaces from where the observation is observed.
+    :return: the decoded observation.
+    """
+    result = []
+    sizes = [s.n for s in spaces][::-1]
+    shift = reduce(lambda x, y: x*y, sizes) // sizes[0]
+    for size in sizes[1:]:
+        r = obs // shift
+        result.append(r)
+        obs %= shift
+        shift //= size
+
+    result.append(obs)
+    return result[::-1]

--- a/gym_breakout_pygame/wrappers/observation_space.py
+++ b/gym_breakout_pygame/wrappers/observation_space.py
@@ -1,9 +1,9 @@
 import time
-from functools import reduce
 from typing import Optional
 
 import gym
-from gym.spaces import Dict, Discrete
+import numpy as np
+from gym.spaces import Discrete, MultiDiscrete
 
 from gym_breakout_pygame.breakout_env import Breakout, BreakoutConfiguration
 from gym_breakout_pygame.utils import encode
@@ -24,27 +24,21 @@ class BreakoutN(gym.ObservationWrapper):
 
         self._encode = encode
         self._wrapped_obs_space = self._wrap_obs_space(encode=False)
-        self._discrete_spaces = [self._wrapped_obs_space["ball_x"],
-                                 self._wrapped_obs_space["ball_y"],
-                                 self._wrapped_obs_space["ball_dir"],
-                                 self._wrapped_obs_space["paddle_x"]]
 
         self.observation_space = self._wrap_obs_space(encode=self._encode)
 
     def _wrap_obs_space(self, encode=False):
         obs_space = self.env.observation_space
 
-        wrapped_obs_space = Dict({
-            "ball_x": obs_space["ball_x"],
-            "ball_y": obs_space["ball_y"],
-            "ball_dir": obs_space["ball_dir"],
-            "paddle_x": obs_space["paddle_x"],
-        })
+        wrapped_obs_space = MultiDiscrete((
+            obs_space["paddle_x"].n,
+            obs_space["ball_x"].n,
+            obs_space["ball_y"].n,
+            obs_space["ball_dir"].n,
+        ))
 
         if encode:
-            discrete_spaces = list(wrapped_obs_space.spaces.values())
-            max_n = reduce(lambda x, y: x * y, [d.n for d in discrete_spaces])
-            wrapped_obs_space = Discrete(max_n)
+            wrapped_obs_space = Discrete(np.prod(wrapped_obs_space.nvec))
 
         return wrapped_obs_space
 
@@ -56,16 +50,10 @@ class BreakoutN(gym.ObservationWrapper):
         paddle_x = observation["paddle_x"]
 
         if self._encode:
-            wrapped_obs = encode([ball_x, ball_y, ball_dir, paddle_x],
-                                 self._discrete_spaces)
+            wrapped_obs = encode([paddle_x, ball_x, ball_y, ball_dir], self._wrapped_obs_space.nvec)
             return wrapped_obs
         else:
-            return {
-                "ball_x": ball_x,
-                "ball_y": ball_y,
-                "ball_dir": ball_dir,
-                "paddle_x": paddle_x,
-            }
+            return np.asarray([paddle_x, ball_x, ball_y, ball_dir])
 
 
 if __name__ == '__main__':
@@ -80,5 +68,4 @@ if __name__ == '__main__':
         time.sleep(0.01)
         env.render(mode="human")
         obs, r, done, info = env.step(env.action_space.sample())  # take a random action
-        print(obs)
     env.close()

--- a/gym_breakout_pygame/wrappers/observation_space.py
+++ b/gym_breakout_pygame/wrappers/observation_space.py
@@ -1,0 +1,84 @@
+import time
+from functools import reduce
+from typing import Optional
+
+import gym
+from gym.spaces import Dict, Discrete
+
+from gym_breakout_pygame.breakout_env import Breakout, BreakoutConfiguration
+from gym_breakout_pygame.utils import encode
+
+
+class BreakoutN(gym.ObservationWrapper):
+    """
+    Breakout env with observation space composed by:
+    - paddle x position
+    - ball x position
+    - ball y position
+    - ball direction
+
+    """
+
+    def __init__(self, breakout_config: Optional[BreakoutConfiguration] = None, encode=True):
+        super().__init__(Breakout(breakout_config))
+
+        self._encode = encode
+        self._wrapped_obs_space = self._wrap_obs_space(encode=False)
+        self._discrete_spaces = [self._wrapped_obs_space["ball_x"],
+                                 self._wrapped_obs_space["ball_y"],
+                                 self._wrapped_obs_space["ball_dir"],
+                                 self._wrapped_obs_space["paddle_x"]]
+
+        self.observation_space = self._wrap_obs_space(encode=self._encode)
+
+    def _wrap_obs_space(self, encode=False):
+        obs_space = self.env.observation_space
+
+        wrapped_obs_space = Dict({
+            "ball_x": obs_space["ball_x"],
+            "ball_y": obs_space["ball_y"],
+            "ball_dir": obs_space["ball_dir"],
+            "paddle_x": obs_space["paddle_x"],
+        })
+
+        if encode:
+            discrete_spaces = list(wrapped_obs_space.spaces.values())
+            max_n = reduce(lambda x, y: x * y, [d.n for d in discrete_spaces])
+            wrapped_obs_space = Discrete(max_n)
+
+        return wrapped_obs_space
+
+    def observation(self, observation):
+
+        ball_x = observation["ball_x"]
+        ball_y = observation["ball_y"]
+        ball_dir = observation["ball_dir"]
+        paddle_x = observation["paddle_x"]
+
+        if self._encode:
+            wrapped_obs = encode([ball_x, ball_y, ball_dir, paddle_x],
+                                 self._discrete_spaces)
+            return wrapped_obs
+        else:
+            return {
+                "ball_x": ball_x,
+                "ball_y": ball_y,
+                "ball_dir": ball_dir,
+                "paddle_x": paddle_x,
+            }
+
+
+if __name__ == '__main__':
+    config = BreakoutConfiguration(brick_rows=3, brick_cols=3)
+    env = BreakoutN(config)
+    env.reset()
+    env.render(mode="human")
+    print("Obs space: ", env.observation_space)
+    print("Act space: ", env.action_space)
+    done = False
+    while not done:
+        time.sleep(0.01)
+        env.render(mode="human")
+        obs, r, done, info = env.step(env.action_space.sample())  # take a random action
+        print(obs)
+    env.close()


### PR DESCRIPTION
The wrapper `BreakoutN` (defined in `gym_breakout_pygame.wrappers.observation_space`) transform the default observation space of `gym_breakout_pygame.breakout_env.Breakout`:
```
self.observation_space = DictSpace({
    "ball_x": Discrete(self.config.n_ball_x),
    "ball_y": Discrete(self.config.n_ball_y),
    "ball_dir": Discrete(self.config.n_ball_dir),
    "paddle_x": Discrete(self.config.n_paddle_x),
    "bricks_matrix": MultiDiscrete([2] * self.config.brick_cols * self.config.brick_rows)
})
```

into:

```
wrapped_obs_space = MultiDiscrete((
    obs_space["paddle_x"].n,
    obs_space["ball_x"].n,
    obs_space["ball_y"].n,
    obs_space["ball_dir"].n,
))
```

So it is more easily usable by common reinforcement learning framework.